### PR TITLE
Reduce timeline left padding and align labels (Fixes #7)

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -296,7 +296,7 @@ export default function Page() {
                         <BreaksSection breaks={breaks} />
                       </div>
                     )}
-                    <div className="relative flex gap-16">
+                    <div className="relative flex gap-3 md:gap-10 pl-14 lg:pl-1">
                       {showTimeline && (
                         <Timeline
                           timelineItems={timelineItems}

--- a/components/Timeline.jsx
+++ b/components/Timeline.jsx
@@ -53,7 +53,7 @@ export function Timeline({ timelineItems, uniqueTimes, cardRefs }) {
                     : "text-muted-foreground")
                 }
                 style={{
-                  left: "calc(100% + 10px)",
+                  right: "calc(100% + 10px)",
                   top: "50%",
                   transform: "translateY(-50%)",
                 }}


### PR DESCRIPTION
After changes
<img width="1512" height="772" alt="Screenshot 2026-07-06 002557" src="https://github.com/user-attachments/assets/f76855b0-d6b5-4ba3-93c1-fee3325ae361" />
<img width="632" height="796" alt="Screenshot 2026-07-06 002536" src="https://github.com/user-attachments/assets/07df27af-6b48-424e-8d62-c5d057366486" />
